### PR TITLE
DRONI-110-`Naver`-로그인-연결

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DRONI_BASE_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ app.*.map.json
 .fvm/
 
 lib/api/swagger/
+
+.env

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
   "cmake.configureOnOpen": false,
   "dart.flutterSdkPath": ".fvm/versions/3.19.4",
-  "cSpell.words": ["Naver"]
+  "cSpell.words": [
+    "Naver"
+  ]
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,9 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:droni/shared/themes/app_theme.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'features/authentication/view/login_screen.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:droni/features/main_navigation/view/main_navigation_screen.dart';
 
 void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  await dotenv.load(fileName: '.env');
   runApp(const App());
 }
 
@@ -16,11 +20,21 @@ class App extends StatefulWidget {
 }
 
 class AppState extends State<App> {
-  late final FlutterSecureStorage storage;
+  bool isLoggined = false;
+
   @override
   void initState() {
-    storage = const FlutterSecureStorage();
+    test();
     super.initState();
+  }
+
+  Future<void> test() async {
+    const storage = FlutterSecureStorage();
+    final accessToken = await storage.read(key: 'access_token');
+
+    setState(() {
+      isLoggined = accessToken != null;
+    });
   }
 
   @override
@@ -31,10 +45,11 @@ class AppState extends State<App> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-        title: 'Droni',
-        debugShowCheckedModeBanner: false,
-        theme: lightTheme,
-        // home: const LoginScreen(),
-        home: const MainNavigationScreen());
+      title: 'Droni',
+      debugShowCheckedModeBanner: false,
+      theme: lightTheme,
+      home: isLoggined ? const MainNavigationScreen() : const LoginScreen(),
+      // home: const MainNavigationScreen(),
+    );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -262,6 +262,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_dotenv:
+    dependency: "direct main"
+    description:
+      name: flutter_dotenv
+      sha256: "9357883bdd153ab78cbf9ffa07656e336b8bbb2b5a3ca596b0b27e119f7c7d77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   riverpod: ^2.5.1
   flutter_web_auth_2: ^3.1.2
   flutter_secure_storage: ^9.2.2
+  flutter_dotenv: ^5.1.0
 
 dev_dependencies:
   flutter_test:
@@ -91,6 +92,7 @@ flutter:
     - assets/image/darkmode/
     - assets/translations/
     - assets/
+    - .env
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware


### PR DESCRIPTION
네이버 로그인 로직을 연결했습니다.

받은 access_token, refresh_token을 secure storage에 저장하고 가져올 수 있도록 작성했습니다.

이후 로그인 로직을 분리하는 view model과 데이터를 class화하는 model을 만들어야 합니다.