### PR TITLE
Droni 127 사용자 메인화면 인기 조종사 API 연결

### DIFF
--- a/lib/features/authentication/view/login_screen.dart
+++ b/lib/features/authentication/view/login_screen.dart
@@ -1,7 +1,6 @@
-import 'dart:developer';
-
 import 'package:droni/features/main_navigation/view/main_navigation_screen.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:gap/gap.dart';
@@ -90,22 +89,30 @@ class _LoginScreenState extends State<LoginScreen> {
               ),
               Column(
                 children: [
-                  Container(
-                    width: double.infinity,
-                    height: 54,
-                    decoration: BoxDecoration(
-                      color: const Color(0xffF9e007),
-                      borderRadius: BorderRadius.circular(8),
+                  GestureDetector(
+                    onTap: () => Navigator.pushReplacement(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const MainNavigationScreen(),
+                      ),
                     ),
-                    child: const Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Text(
-                          '카카오로 3초만에 시작하기',
-                          textAlign: TextAlign.center,
-                          style: system05,
-                        ),
-                      ],
+                    child: Container(
+                      width: double.infinity,
+                      height: 54,
+                      decoration: BoxDecoration(
+                        color: const Color(0xffF9e007),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: const Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text(
+                            '카카오로 3초만에 시작하기',
+                            textAlign: TextAlign.center,
+                            style: system05,
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                   const Gap(8),

--- a/lib/features/user_home/view/widgets/popular_pilots.dart
+++ b/lib/features/user_home/view/widgets/popular_pilots.dart
@@ -1,6 +1,3 @@
-import 'dart:developer';
-
-import 'package:droni/api/generated/openAPI.swagger.dart';
 import 'package:droni/shared/constants/app_colors.dart';
 import 'package:droni/shared/utils/api_client.dart';
 import 'package:droni/shared/widgets/svg_icon.dart';
@@ -41,31 +38,38 @@ class PopularPilots extends StatelessWidget {
           SizedBox(
             height: 88,
             child: FutureBuilder(
-              // future: client.articleHowToUseSummaryGet(
-              //   articleTarget: ArticleHowToUseSummaryGetArticleTarget.all,
-              // ),
-              future: client.homeBannerGet(),
+              future: mockClient.homePopularPilotGet(),
+              // future: client.homePopularPilotGet(),
               builder: (context, snapshot) {
-                log(snapshot.data.toString());
+                if (snapshot.connectionState == ConnectionState.none ||
+                    snapshot.connectionState == ConnectionState.active ||
+                    snapshot.connectionState == ConnectionState.none ||
+                    snapshot.data == null ||
+                    !snapshot.hasData) {
+                  return const CircularProgressIndicator();
+                }
+
+                final pilots = snapshot.data!.body!;
 
                 return ListView.separated(
                   padding: const EdgeInsets.symmetric(horizontal: 24),
-                  itemCount: 8,
+                  itemCount: pilots.length,
                   scrollDirection: Axis.horizontal,
                   itemBuilder: (context, index) => Column(
                     children: [
-                      const SizedBox(
-                        width: 64,
-                        height: 64,
-                        child: CircleAvatar(
-                          backgroundImage: NetworkImage(
-                            'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTDy9bXUES6Lh_0aZMVd1HgHfv8OKhh4WaAdby5wFHxDQ&s',
+                      if (pilots[index].imageUrl != null)
+                        SizedBox(
+                          width: 64,
+                          height: 64,
+                          child: CircleAvatar(
+                            backgroundImage: NetworkImage(
+                              pilots[index].imageUrl!,
+                            ),
                           ),
                         ),
-                      ),
                       const Gap(6),
                       Text(
-                        '조종사1',
+                        pilots[index].nickName ?? '조종사 이름 없음',
                         style: system11.copyWith(color: AppColors.droniGray600),
                       ),
                     ],

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,8 @@
-import 'package:droni/features/authentication/view/login_screen.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:droni/shared/themes/app_theme.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:droni/features/authentication/view/login_screen.dart';
 import 'package:droni/features/main_navigation/view/main_navigation_screen.dart';
 
 void main() async {

--- a/lib/shared/utils/api_client.dart
+++ b/lib/shared/utils/api_client.dart
@@ -1,86 +1,8 @@
-import 'dart:async';
-
+import 'package:droni/shared/utils/custom_interceptor.dart';
 import 'package:chopper/chopper.dart';
 import 'package:droni/api/generated/client_index.dart';
-import 'package:droni/api/generated/openAPI.models.swagger.dart';
-import 'package:droni/features/authentication/view/login_screen.dart';
-import 'package:droni/main.dart';
-import 'package:flutter/material.dart';
+import 'package:droni/shared/utils/mock_open_api.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-
-class CustomInterceptor implements Interceptor {
-  final storage = const FlutterSecureStorage();
-
-  Future<bool> _reissueToken() async {
-    final accessToken = await storage.read(key: 'access_token');
-    final refreshToken = await storage.read(key: 'refresh_token');
-
-    if (accessToken == null || refreshToken == null) {
-      GlobalVariables.navigationKey.currentState?.pushReplacement(
-        MaterialPageRoute(
-          builder: (context) => const LoginScreen(),
-        ),
-      );
-      return false;
-    }
-
-    final res = await client.reissuePost(
-      body: TokenRefreshDto(
-        accessToken: accessToken,
-        refreshToken: refreshToken,
-      ),
-    );
-
-    if (!res.isSuccessful) return false;
-
-    await storage.write(key: 'access_token', value: res.body?.accessToken);
-    await storage.write(key: 'refresh_token', value: res.body?.refreshToken);
-
-    return res.isSuccessful;
-  }
-
-  Future<Request> _addAuthorizationHeader(Request request) async {
-    final accessToken = await storage.read(key: 'access_token');
-    return applyHeader(request, 'Authorization', 'Bearer $accessToken');
-  }
-
-  @override
-  FutureOr<Response<BodyType>> intercept<BodyType>(
-    Chain<BodyType> chain,
-  ) async {
-    if (chain.request.uri.path.contains('reissue')) {
-      return await chain.proceed(chain.request);
-    }
-
-    var request = await _addAuthorizationHeader(chain.request);
-
-    final response = await chain.proceed(request);
-
-    if (response.statusCode == 401) {
-      GlobalVariables.navigationKey.currentState?.pushReplacement(
-        MaterialPageRoute(
-          builder: (context) => const LoginScreen(),
-        ),
-      );
-
-      return response;
-    }
-
-    if (response.statusCode == 406) {
-      final isReissued = await _reissueToken();
-
-      if (!isReissued) {
-        return response;
-      }
-
-      request = await _addAuthorizationHeader(chain.request);
-      return await chain.proceed(request);
-    }
-
-    return response;
-  }
-}
 
 final client = OpenAPI.create(
   baseUrl: Uri.parse(dotenv.env['DRONI_BASE_URL'] ?? ''),
@@ -89,3 +11,5 @@ final client = OpenAPI.create(
     CustomInterceptor(),
   ],
 );
+
+final mockClient = MockOpenAPI();

--- a/lib/shared/utils/custom_interceptor.dart
+++ b/lib/shared/utils/custom_interceptor.dart
@@ -1,0 +1,84 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import 'package:chopper/chopper.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import 'package:droni/main.dart';
+import 'package:droni/shared/utils/api_client.dart';
+import 'package:droni/api/generated/openAPI.models.swagger.dart';
+import 'package:droni/features/authentication/view/login_screen.dart';
+
+class CustomInterceptor implements Interceptor {
+  final storage = const FlutterSecureStorage();
+
+  Future<bool> _reissueToken() async {
+    final accessToken = await storage.read(key: 'access_token');
+    final refreshToken = await storage.read(key: 'refresh_token');
+
+    if (accessToken == null || refreshToken == null) {
+      GlobalVariables.navigationKey.currentState?.pushReplacement(
+        MaterialPageRoute(
+          builder: (context) => const LoginScreen(),
+        ),
+      );
+      return false;
+    }
+
+    final res = await client.reissuePost(
+      body: TokenRefreshDto(
+        accessToken: accessToken,
+        refreshToken: refreshToken,
+      ),
+    );
+
+    if (!res.isSuccessful) return false;
+
+    await storage.write(key: 'access_token', value: res.body?.accessToken);
+    await storage.write(key: 'refresh_token', value: res.body?.refreshToken);
+
+    return res.isSuccessful;
+  }
+
+  Future<Request> _addAuthorizationHeader(Request request) async {
+    final accessToken = await storage.read(key: 'access_token');
+    return applyHeader(request, 'Authorization', 'Bearer $accessToken');
+  }
+
+  @override
+  FutureOr<Response<BodyType>> intercept<BodyType>(
+    Chain<BodyType> chain,
+  ) async {
+    if (chain.request.uri.path.contains('reissue')) {
+      return await chain.proceed(chain.request);
+    }
+
+    var request = await _addAuthorizationHeader(chain.request);
+
+    final response = await chain.proceed(request);
+
+    if (response.statusCode == 401) {
+      GlobalVariables.navigationKey.currentState?.pushReplacement(
+        MaterialPageRoute(
+          builder: (context) => const LoginScreen(),
+        ),
+      );
+
+      return response;
+    }
+
+    if (response.statusCode == 406) {
+      final isReissued = await _reissueToken();
+
+      if (!isReissued) {
+        return response;
+      }
+
+      request = await _addAuthorizationHeader(chain.request);
+      return await chain.proceed(request);
+    }
+
+    return response;
+  }
+}

--- a/lib/shared/utils/mock_open_api.dart
+++ b/lib/shared/utils/mock_open_api.dart
@@ -1,0 +1,102 @@
+import 'dart:math';
+import 'package:chopper/chopper.dart';
+import 'package:droni/api/generated/openAPI.swagger.dart';
+import 'package:droni/shared/utils/mock_response.dart';
+import 'package:faker/faker.dart';
+
+class MockOpenAPI implements OpenAPI {
+  Duration delay = const Duration(seconds: 2);
+
+  @override
+  final Type definitionType = OpenAPI;
+
+  @override
+  Future<Response<List<DroniFile>>> homeBannerGet() async {
+    await Future.delayed(delay);
+
+    const bannerBaseUrl = 'https://picsum.photos/id';
+    final List<DroniFile> banners = [];
+
+    for (var i = 0; i < 5; i++) {
+      final banner = DroniFile(
+        id: i + 1,
+        name: 'banner ${i + 1}',
+        path: '$bannerBaseUrl/${Random().nextInt(100) + 1}/1200/500',
+      );
+
+      banners.add(banner);
+    }
+
+    final response = Response(MockResponse(), banners);
+
+    return Future.value(response);
+  }
+
+  @override
+  Future<Response<List<PilotProfile>>> homePopularPilotGet() async {
+    await Future.delayed(delay);
+
+    final List<PilotProfile> pilots = [];
+
+    for (var i = 0; i < 5; i++) {
+      var faker = Faker();
+      var pilot = PilotProfile(
+        expertId: i + 1,
+        nickName: faker.internet.userName(),
+        imageUrl:
+            'https://randomuser.me/api/portraits/${Random().nextBool() ? '' : 'wo'}men/${Random().nextInt(100)}.jpg',
+      );
+
+      pilots.add(pilot);
+    }
+
+    final response = Response(
+      MockResponse(),
+      pilots,
+    );
+
+    return Future.value(response);
+  }
+
+  @override
+  ChopperClient client = ChopperClient();
+
+  @override
+  Future<Response<List<ArticleSummaryResponse>>>
+      articleDroneContentSummaryGet() {
+    // TODO: implement articleDroneContentSummaryGet
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Response<List<ArticleSummaryResponse>>> articleHowToUseSummaryGet(
+      {ArticleHowToUseSummaryGetArticleTarget? articleTarget}) {
+    // TODO: implement articleHowToUseSummaryGet
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Response<List<PopularExpert>>> expertPopularGet() {
+    // TODO: implement expertPopularGet
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Response<String>> expireTestGet() {
+    // TODO: implement expireTestGet
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Response<TokenRefreshDto>> reissuePost(
+      {required TokenRefreshDto? body}) {
+    // TODO: implement reissuePost
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Response<String>> sucessTestGet() {
+    // TODO: implement sucessTestGet
+    throw UnimplementedError();
+  }
+}

--- a/lib/shared/utils/mock_response.dart
+++ b/lib/shared/utils/mock_response.dart
@@ -1,0 +1,24 @@
+import 'package:http/http.dart' as http;
+
+class MockResponse implements http.BaseResponse {
+  @override
+  int? get contentLength => 100;
+
+  @override
+  Map<String, String> get headers => {'Auth': ''};
+
+  @override
+  bool get isRedirect => false;
+
+  @override
+  bool get persistentConnection => false;
+
+  @override
+  String? get reasonPhrase => 'reasonPhrase';
+
+  @override
+  http.BaseRequest? get request => throw UnimplementedError();
+
+  @override
+  int get statusCode => 200;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -233,6 +233,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  faker:
+    dependency: "direct main"
+    description:
+      name: faker
+      sha256: "746e59f91d8b06a389e74cf76e909a05ed69c12691768e2f93557fdf29200fd0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   ffi:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   flutter_web_auth_2: ^3.1.2
   flutter_secure_storage: ^9.2.2
   flutter_dotenv: ^5.1.0
+  faker: ^2.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
1. 테스트용 API를 실행시킬때 사용되는 faker 라이브러리를 추가했습니다.
2. 서버 없이 사용가능한 테스트용(mock-up) API를 구현했습니다(popular-pilot까지만 적용).
3. 카카오톡 로그인 클릭시 바로 메인화면으로 넘어가도록 임시 기능을 넣었습니다.
4. 인기 조종사 API를 연결했습니다. 