### PR TITLE
Droni 156 채팅 리스트 화면 구현

### DIFF
--- a/lib/features/chat/view/chat_list_screen.dart
+++ b/lib/features/chat/view/chat_list_screen.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+import 'package:gap/gap.dart';
+
+import 'package:droni/shared/widgets/svg_icon.dart';
+import 'package:droni/shared/constants/app_colors.dart';
+import 'package:droni/shared/constants/text_style.dart';
+
+import 'package:droni/features/chat/view/widgets/chat_list_card.dart';
+import 'package:droni/features/chat/view/widgets/chat_list_tab_bar.dart';
+
+class ChatListScreen extends StatelessWidget {
+  const ChatListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 3,
+      child: NestedScrollView(
+        headerSliverBuilder: (context, innerBoxIsScrolled) {
+          return [
+            SliverAppBar(
+              titleSpacing: 13,
+              title: Text(
+                '채팅',
+                style: system03.copyWith(
+                  color: AppColors.droniGray800,
+                ),
+              ),
+              actions: const [
+                Padding(
+                  padding: EdgeInsets.only(right: 20, top: 13, bottom: 13),
+                  child: SvgIcon(
+                    icon: 'assets/image/icon/notification_unread_true.svg',
+                    height: 26,
+                  ),
+                )
+              ],
+            ),
+            SliverPersistentHeader(
+              pinned: true,
+              delegate: ChatListTabBar(),
+            )
+          ];
+        },
+        body: TabBarView(
+          children: [
+            ListView.separated(
+              itemCount: 2,
+              itemBuilder: (context, index) => ChatListCard(
+                isReviewRequired: index % 2 != 0,
+              ),
+              separatorBuilder: (context, index) => const Gap(8),
+            ),
+            ListView.separated(
+              itemCount: 2,
+              itemBuilder: (context, index) => const ChatListCard(
+                isReviewRequired: false,
+              ),
+              separatorBuilder: (context, index) => const Gap(8),
+            ),
+            ListView.separated(
+              itemCount: 2,
+              itemBuilder: (context, index) => const ChatListCard(
+                isReviewRequired: true,
+              ),
+              separatorBuilder: (context, index) => const Gap(8),
+            ),
+          ],
+        ),
+      ),
+      // child: Column(
+      //   children: [
+      //     Padding(
+      //       padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 13),
+      //       child: Row(
+      //         mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      //         children: [
+      //           Text(
+      //             '채팅',
+      //             style: system03.copyWith(
+      //               color: AppColors.droniGray800,
+      //             ),
+      //           ),
+      //         ],
+      //       ),
+      //     ),
+      //     const Gap(11),
+      //     SingleChildScrollView(
+      //       child: SizedBox(
+      //         width: MediaQuery.of(context).size.width,
+      //         height: MediaQuery.of(context).size.height,
+      //         child: const       //       ),
+      //     )
+      //   ],
+      // ),
+    );
+  }
+}

--- a/lib/features/chat/view/chat_screen.dart
+++ b/lib/features/chat/view/chat_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class ChatScreen extends StatelessWidget {
+  const ChatScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Chat'),
+      ),
+      body: const Center(
+        child: Text('chat'),
+      ),
+    );
+  }
+}

--- a/lib/features/chat/view/widgets/chat_list_card.dart
+++ b/lib/features/chat/view/widgets/chat_list_card.dart
@@ -1,0 +1,136 @@
+import 'package:droni/features/chat/view/chat_screen.dart';
+import 'package:flutter/material.dart';
+
+import 'package:gap/gap.dart';
+
+import 'package:droni/shared/constants/app_colors.dart';
+import 'package:droni/shared/constants/text_style.dart';
+
+class ChatListCard extends StatelessWidget {
+  const ChatListCard({super.key, required this.isReviewRequired});
+
+  final bool isReviewRequired;
+
+  void _cardOnTap(BuildContext context) {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => const ChatScreen(),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () => _cardOnTap(context),
+      child: Container(
+        decoration: const BoxDecoration(color: Colors.white),
+        padding: const EdgeInsets.symmetric(
+          horizontal: 20,
+          vertical: 16,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                const SizedBox(
+                  width: 34,
+                  height: 34,
+                  child: CircleAvatar(),
+                ),
+                const Gap(8),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '김철수',
+                      style: system07.copyWith(
+                        color: AppColors.droniGray800,
+                      ),
+                    ),
+                    IntrinsicHeight(
+                      child: Row(
+                        children: [
+                          Text(
+                            '★',
+                            style: system10.copyWith(
+                              color: Colors.yellow,
+                            ),
+                          ),
+                          const Gap(2),
+                          Text(
+                            '4.9',
+                            style: system11.copyWith(
+                              color: AppColors.droniGray700,
+                            ),
+                          ),
+                          const VerticalDivider(
+                            color: AppColors.droniGray200,
+                          ),
+                          Text(
+                            '충정특별시 서산면',
+                            style: system11.copyWith(
+                              color: AppColors.droniGray500,
+                            ),
+                          )
+                        ],
+                      ),
+                    )
+                  ],
+                ),
+              ],
+            ),
+            const Gap(12),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  '네. 그럼 농장 위치 부탁드립니다!',
+                  style: system10.copyWith(
+                    color: AppColors.droniGray700,
+                  ),
+                ),
+                Text(
+                  '2024.06.02',
+                  style: system12.copyWith(
+                    color: AppColors.droniGray400,
+                  ),
+                )
+              ],
+            ),
+            const Gap(8),
+            const Divider(),
+            const Gap(8),
+            if (!isReviewRequired)
+              Text(
+                '입찰가 35만원',
+                style: system07.copyWith(
+                  color: AppColors.droniBlue600,
+                ),
+              ),
+            if (isReviewRequired)
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.symmetric(vertical: 10),
+                decoration: BoxDecoration(
+                  border: Border.all(
+                    width: 1,
+                    color: AppColors.droniGray300,
+                  ),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Text(
+                  '리뷰작성',
+                  textAlign: TextAlign.center,
+                  style: system07.copyWith(
+                    color: AppColors.droniGray800,
+                  ),
+                ),
+              )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/chat/view/widgets/chat_list_tab_bar.dart
+++ b/lib/features/chat/view/widgets/chat_list_tab_bar.dart
@@ -1,0 +1,50 @@
+import 'package:droni/shared/constants/app_colors.dart';
+import 'package:droni/shared/constants/text_style.dart';
+import 'package:flutter/material.dart';
+
+class ChatListTabBar extends SliverPersistentHeaderDelegate {
+  @override
+  Widget build(
+      BuildContext context, double shrinkOffset, bool overlapsContent) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        border: Border(
+          bottom: BorderSide(
+            width: 1,
+            color: AppColors.droniGray200,
+          ),
+        ),
+      ),
+      child: const TabBar(
+        tabAlignment: TabAlignment.start,
+        isScrollable: true,
+        labelColor: AppColors.droniGray900,
+        unselectedLabelColor: AppColors.droniGray400,
+        labelPadding: EdgeInsets.only(left: 8, right: 8, bottom: 8),
+        indicatorSize: TabBarIndicatorSize.label,
+        indicatorColor: AppColors.droniGray800,
+        tabs: [
+          Text('전체', style: system05),
+          Text('진행중', style: system05),
+          Text('방제완료', style: system05),
+        ],
+      ),
+    );
+  }
+
+  @override
+  // TODO: implement maxExtent
+  double get maxExtent => 35;
+
+  @override
+  // TODO: implement minExtent
+  double get minExtent => 35;
+
+  @override
+  bool shouldRebuild(covariant SliverPersistentHeaderDelegate oldDelegate) {
+    return false;
+  }
+}

--- a/lib/features/main_navigation/view/main_navigation_screen.dart
+++ b/lib/features/main_navigation/view/main_navigation_screen.dart
@@ -1,8 +1,11 @@
-import 'package:droni/features/user_home/view/widgets/home_app_bar.dart';
-import 'package:droni/features/user_home/view/widgets/home_fab.dart';
-import 'package:droni/features/main_navigation/view/widgets/nav_tab.dart';
 import 'package:flutter/material.dart';
+
+import 'package:droni/features/chat/view/chat_list_screen.dart';
 import 'package:droni/features/user_home/view/home_screen.dart';
+import 'package:droni/features/user_home/view/widgets/home_fab.dart';
+import 'package:droni/features/user_home/view/widgets/home_app_bar.dart';
+
+import '../view/widgets/nav_tab.dart';
 
 class MainNavigationScreen extends StatefulWidget {
   const MainNavigationScreen({super.key});
@@ -41,7 +44,7 @@ class _MainNavigationScreenState extends State<MainNavigationScreen> {
             ),
             Offstage(
               offstage: _selectedIndex != 3,
-              child: const Text('채팅'),
+              child: const ChatListScreen(),
             ),
             Offstage(
               offstage: _selectedIndex != 4,


### PR DESCRIPTION
Bottom Naivgation에서 채팅을 탭했을 경우 나오는 채팅 리스트 화면을 구현했습니다.
간단한게 카드를 탭하면 채팅 화면으로 이동하도록 연결만 했습니다.

점점 연결해야하는 화면이 많아지면서 화면 이동관련 라이브러리의 필요성을 느끼고 있습니다.
제가 사용했던건 go_router라서 만약 추가한다면 go_router를 추가할 것 같습니다.

라이브러리를 추가하는것에 대해서 어떤지 말씀해주시고 더 편한 라이브러리가 있다면 말씀해주세요!